### PR TITLE
Add minimal Spring Boot project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+.gradle/
+/build/
+/out/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # test_repo
-just test
+
+This repository contains a minimal Spring Boot project using Java 17.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'org.springframework.boot' version '3.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+jar {
+    enabled = false
+}
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'demo'

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,11 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/demo/controller/HelloController.java
+++ b/src/main/java/com/example/demo/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, World";
+    }
+}

--- a/src/main/java/com/example/demo/dto/HelloDto.java
+++ b/src/main/java/com/example/demo/dto/HelloDto.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto;
+
+public class HelloDto {
+    private String message;
+
+    public HelloDto() {
+    }
+
+    public HelloDto(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/demo/repository/HelloRepository.java
+++ b/src/main/java/com/example/demo/repository/HelloRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class HelloRepository {
+    // This class can be expanded to interact with data sources
+}

--- a/src/main/java/com/example/demo/service/HelloService.java
+++ b/src/main/java/com/example/demo/service/HelloService.java
@@ -1,0 +1,10 @@
+package com.example.demo.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HelloService {
+    public String getGreeting() {
+        return "Hello, World";
+    }
+}

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a Java 17 Spring Boot project
- create basic `controller`, `service`, `repository`, and `dto` packages
- include a simple REST controller and supporting classes
- update README
- add ignore rules for Gradle build outputs

## Testing
- `gradle test` *(fails: Plugin not found - offline)*

------
https://chatgpt.com/codex/tasks/task_e_6864a09a59548326a8bee0ff38bd2ff6