### PR TITLE
Add time endpoint

### DIFF
--- a/src/main/java/com/example/demo/controller/HelloController.java
+++ b/src/main/java/com/example/demo/controller/HelloController.java
@@ -2,6 +2,9 @@ package com.example.demo.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 @RestController
 public class HelloController {
@@ -9,5 +12,12 @@ public class HelloController {
     @GetMapping("/hello")
     public String hello() {
         return "Hello, World";
+    }
+
+    @GetMapping("/time")
+    public String time() {
+        LocalDateTime nowSeoul = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return nowSeoul.format(formatter);
     }
 }


### PR DESCRIPTION
## Summary
- add `/time` endpoint that returns the current time in Korea/Seoul timezone

## Testing
- `gradle test` *(fails: Plugin not found due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6864a24525608326b091bc7859290a52